### PR TITLE
Change var to let

### DIFF
--- a/kumu/kumu.h
+++ b/kumu/kumu.h
@@ -432,7 +432,7 @@ typedef enum {
   // Keywords.
   TOK_AND, TOK_CLASS, TOK_ELSE, TOK_FALSE, TOK_FOR, TOK_FUN,
   TOK_IF, TOK_NIL, TOK_OR, TOK_RETURN, TOK_SUPER,
-  TOK_THIS, TOK_TRUE, TOK_VAR, TOK_WHILE, TOK_ERR, TOK_EOF,
+  TOK_THIS, TOK_TRUE, TOK_LET, TOK_WHILE, TOK_ERR, TOK_EOF,
   TOK_BREAK, TOK_CONTINUE,
 } kutok_t;
 
@@ -481,7 +481,7 @@ typedef struct kucomp {
 void ku_compinit(kuvm *vm, kucomp *compiler, kufunc_t type);
 void ku_beginscope(kuvm *vm);
 void ku_endscope(kuvm *vm);
-void ku_declare_var(kuvm *vm);
+void ku_declare_let(kuvm *vm);
 void ku_addlocal(kuvm *vm, kutok name);
 bool ku_identeq(kuvm *vm, kutok *a, kutok *b);
 int ku_resolvelocal(kuvm *vm, kucomp *compiler, kutok *name);

--- a/kumu/kutest.c
+++ b/kumu/kutest.c
@@ -75,7 +75,7 @@ kuval ku_get_global(kuvm* vm, const char* name) {
 
 kuval ku_test_eval(kuvm* vm, const char* expr) {
   char buff[255];
-  sprintf(buff, "var x = %s;", expr);
+  sprintf(buff, "let x = %s;", expr);
   kures res = ku_exec(vm, buff);
   if (res != KVM_OK) {
     return NIL_VAL;
@@ -254,30 +254,30 @@ void kut_free(kuvm* vm) {
 
 void ku_test() {
   kuvm *vm = kut_new(false);
-  kures res = ku_exec(vm, "var x= -1+4;");
-  EXPECT_INT(vm, res, KVM_OK, "var x= -1+4 res");
+  kures res = ku_exec(vm, "let x= -1+4;");
+  EXPECT_INT(vm, res, KVM_OK, "let x= -1+4 res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = -1+4;");
+  res = ku_exec(vm, "let x = -1+4;");
   EXPECT_INT(vm, res, KVM_OK, "-1+4 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(-1+4), "-1+4 ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = (-(1+2)-4)*5/6;");
+  res = ku_exec(vm, "let x = (-(1+2)-4)*5/6;");
   EXPECT_INT(vm, res, KVM_OK, "ku_run res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL((-(1.0+2.0)-4.0)*5.0/6.0), "ku_run ret");
   kut_free(vm);
   
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 1+2;");
+  res = ku_exec(vm, "let x = 1+2;");
   EXPECT_INT(vm, res, KVM_OK, "ku_exec res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "ku_exec ret");
   kut_free(vm);
   
   vm = kut_new(false);
-  ku_lexinit(vm, "var x = 12+3;");
+  ku_lexinit(vm, "let x = 12+3;");
   ku_lexdump(vm);
   kut_free(vm);
   
@@ -287,7 +287,7 @@ void ku_test() {
   kut_free(vm);
   
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = (1+2)*3;");
+  res = ku_exec(vm, "let x = (1+2)*3;");
   EXPECT_INT(vm, res, KVM_OK, "grouping res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "grouping ret");
   kut_free(vm);
@@ -302,7 +302,7 @@ void ku_test() {
   kut_free(vm);
   
   vm = kut_new(false);
-  ku_lexinit(vm, "var x=30; \n  x=\"hello\";");
+  ku_lexinit(vm, "let x=30; \n  x=\"hello\";");
   ku_lexdump(vm);
   kut_free(vm);
 
@@ -315,7 +315,7 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = -2*3;");
+  res = ku_exec(vm, "let x = -2*3;");
   EXPECT_INT(vm, res, KVM_OK, "unary res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(-6), "unary ret");
   kut_free(vm);
@@ -328,14 +328,14 @@ void ku_test() {
 
   // ku_print_val
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 2+3;");
+  res = ku_exec(vm, "let x = 2+3;");
   kuval v = ku_get_global(vm, "x");
   EXPECT_VAL(vm, v, NUM_VAL(5), "ku_print_val ret");
   ku_printval(vm, v);
   kut_free(vm);
   
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 12.3;");
+  res = ku_exec(vm, "let x = 12.3;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(12.3), "ku_lex_peeknext ret");
   kut_free(vm);
   
@@ -542,12 +542,12 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 12 < true;");
+  res = ku_exec(vm, "let x = 12 < true;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "< num expected");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 12 + true;");
+  res = ku_exec(vm, "let x = 12 + true;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "add num expected");
   kut_free(vm);
 
@@ -613,7 +613,7 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 20;");
+  res = ku_exec(vm, "let x = 20;");
   EXPECT_INT(vm, res, KVM_OK, "global decl");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(20), "global init");
   res = ku_exec(vm, "x = 30;");
@@ -628,34 +628,34 @@ void ku_test() {
   kut_free(vm);
   
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 20; var y = 0; { var a=x*20; y = a; }");
+  res = ku_exec(vm, "let x = 20; let y = 0; { let a=x*20; y = a; }");
   EXPECT_INT(vm, res, KVM_OK, "local decl");
   EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(400), "local init");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "{ var a = a; }");
+  res = ku_exec(vm, "{ let a = a; }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "local own init");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_DISASM | KVM_F_QUIET;
-  res = ku_exec(vm, "{ var a = 1; var b = 2; }");
+  res = ku_exec(vm, "{ let a = 1; let b = 2; }");
   EXPECT_INT(vm, res, KVM_OK, "local op print");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 10; if (true) { x = 30; }");
+  res = ku_exec(vm, "let x = 10; if (true) { x = 30; }");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(30), "if true");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 10; if (false) { x = 30; }");
+  res = ku_exec(vm, "let x = 10; if (false) { x = 30; }");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(10), "if false");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 10; if (false) x = 30;  else x = 20;");
+  res = ku_exec(vm, "let x = 10; if (false) x = 30;  else x = 20;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(20), "else");
   kut_free(vm);
 
@@ -675,81 +675,81 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = false and true;");
+  res = ku_exec(vm, "let x = false and true;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(false), "false and true");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = false and false;");
+  res = ku_exec(vm, "let x = false and false;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(false), "false and false");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = true and false;");
+  res = ku_exec(vm, "let x = true and false;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(false), "true and false");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = true and true;");
+  res = ku_exec(vm, "let x = true and true;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(true), "true and true");
   kut_free(vm);
   
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = false or true;");
+  res = ku_exec(vm, "let x = false or true;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(true), "false or true");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = false or false;");
+  res = ku_exec(vm, "let x = false or false;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(false), "false or false");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = true or false;");
+  res = ku_exec(vm, "let x = true or false;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(true), "true or false");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = true or true;");
+  res = ku_exec(vm, "let x = true or true;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), BOOL_VAL(true), "true or true");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 1; while(x < 20) { x = x + 1; }");
+  res = ku_exec(vm, "let x = 1; while(x < 20) { x = x + 1; }");
   EXPECT_INT(vm, res, KVM_OK, "while parse");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(20), "while simple");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 1; while x < 20) { x = x + 1; }");
+  res = ku_exec(vm, "let x = 1; while x < 20) { x = x + 1; }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "while no lpar");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 1; while (x < 20 { x = x + 1; }");
+  res = ku_exec(vm, "let x = 1; while (x < 20 { x = x + 1; }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "while no rpar");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 0; for(var j=0; j < 10; j=j+1) x = j;");
+  res = ku_exec(vm, "let x = 0; for(let j=0; j < 10; j=j+1) x = j;");
   EXPECT_INT(vm, res, KVM_OK, "for parse");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "for simple");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 0; for var j=0; j < 10; j=j+1) x = j;");
+  res = ku_exec(vm, "let x = 0; for let j=0; j < 10; j=j+1) x = j;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "for no lpar");
   kut_free(vm);
 
   vm = kut_new(true);
   vm->flags = 0;
-  res = ku_exec(vm, "var x = 0; for(; x < 10; x=x+1) printf(x); printf(\"\n\");");
+  res = ku_exec(vm, "let x = 0; for(; x < 10; x=x+1) printf(x); printf(\"\n\");");
   EXPECT_INT(vm, res, KVM_OK, "for no init");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(10), "for no init");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = 0; for(; x < 10; ) x=x+1;");
+  res = ku_exec(vm, "let x = 0; for(; x < 10; ) x=x+1;");
   EXPECT_INT(vm, res, KVM_OK, "for no inc");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(10), "for no inc");
   kut_free(vm);
@@ -790,61 +790,61 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 return fun foo()");
+  res = ku_exec(vm, "let x=2 return fun foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip return");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 fun foo()");
+  res = ku_exec(vm, "let x=2 fun foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip fun");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 class foo()");
+  res = ku_exec(vm, "let x=2 class foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip class");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 var foo()");
-  EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip var");
+  res = ku_exec(vm, "let x=2 let foo()");
+  EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip let");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 for foo()");
+  res = ku_exec(vm, "let x=2 for foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip for");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 if foo()");
+  res = ku_exec(vm, "let x=2 if foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip if");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=2 while foo()");
+  res = ku_exec(vm, "let x=2 while foo()");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "parse_skip while");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun f(a) { return a*2; }\nvar x = f(3);");
+  res = ku_exec(vm, "fun f(a) { return a*2; }\nlet x = f(3);");
   EXPECT_INT(vm, res, KVM_OK, "return expr res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "return expr val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun f(a) { var z = 2; }\nvar x = f(3);");
+  res = ku_exec(vm, "fun f(a) { let z = 2; }\nlet x = f(3);");
   EXPECT_INT(vm, res, KVM_OK, "implicit return res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "implicit return val");
   kut_free(vm);
 
   vm = kut_new(false);
   ku_cfuncdef(vm, "nadd", kutest_native_add);
-  res = ku_exec(vm, "var x = nadd(3,4);");
+  res = ku_exec(vm, "let x = nadd(3,4);");
   EXPECT_INT(vm, res, KVM_OK, "cfunc res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(7), "cfunc return");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = clock();");
+  res = ku_exec(vm, "let x = clock();");
   EXPECT_INT(vm, res, KVM_OK, "clock res");
   v = ku_get_global(vm, "x");
   EXPECT_INT(vm, IS_NUM(v), true, "clock return");
@@ -856,32 +856,32 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun M(x) { var m = x; fun e(n) { return m*n; } return e; }\n var z = M(5); var x = z(3);");
+  res = ku_exec(vm, "fun M(x) { let m = x; fun e(n) { return m*n; } return e; }\n let z = M(5); let x = z(3);");
   EXPECT_INT(vm, res, KVM_OK, "closure res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(15), "closure val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun o() { var a=7; var b=8; fun i() { return a+b; } return i; }\n var z = o(); var x = z();");
+  res = ku_exec(vm, "fun o() { let a=7; let b=8; fun i() { return a+b; } return i; }\n let z = o(); let x = z();");
   EXPECT_INT(vm, res, KVM_OK, "closure2 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(15), "closure2 val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun f1(){var a1=1; fun f2() {var a2=2; fun f3(){ return a1+a2; } return f3; } return f2; }\n var v1=f1(); var v2=v1(); var v3=v2();");
+  res = ku_exec(vm, "fun f1(){let a1=1; fun f2() {let a2=2; fun f3(){ return a1+a2; } return f3; } return f2; }\n let v1=f1(); let v2=v1(); let v3=v2();");
   EXPECT_INT(vm, res, KVM_OK, "closure3 res");
   EXPECT_VAL(vm, ku_get_global(vm, "v3"), NUM_VAL(3), "closure3 val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun M(x) { var m = x; fun e() { return m*m; } return e; }\n var z = M(5); var x = z();");
+  res = ku_exec(vm, "fun M(x) { let m = x; fun e() { return m*m; } return e; }\n let z = M(5); let x = z();");
   EXPECT_INT(vm, res, KVM_OK, "closure4 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(25), "closure4 val");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_GCSTRESS | KVM_F_GCLOG | KVM_F_QUIET;
-  res = ku_exec(vm, "var x = \"hello\"; x=nil;");
+  res = ku_exec(vm, "let x = \"hello\"; x=nil;");
   ku_gc(vm);
   EXPECT_INT(vm, res, KVM_OK, "gc res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "gc val");
@@ -890,7 +890,7 @@ void ku_test() {
   vm = kut_new(false);
   vm->flags = KVM_F_GCLOG | KVM_F_QUIET;
   vm->gcnext = 0;
-  res = ku_exec(vm, "var x = \"hello\"; x=nil;");
+  res = ku_exec(vm, "let x = \"hello\"; x=nil;");
   EXPECT_INT(vm, res, KVM_OK, "gcnext res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "gcnext val");
   kut_free(vm);
@@ -903,7 +903,7 @@ void ku_test() {
 
   vm = kut_new(false);
   vm->flags = KVM_F_GCSTRESS | KVM_F_GCLOG | KVM_F_QUIET;
-  res = ku_exec(vm, "fun M(x) { var m = x; fun e() { return m*m; } return e; }\n var z = M(5); var x = z(); x = nil;");
+  res = ku_exec(vm, "fun M(x) { let m = x; fun e() { return m*m; } return e; }\n let z = M(5); let x = z(); x = nil;");
   ku_gc(vm);
   EXPECT_INT(vm, res, KVM_OK, "gc closure res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "gc closure val");
@@ -911,22 +911,22 @@ void ku_test() {
 
   vm = kut_new(false);
   vm->flags = KVM_F_GCSTRESS | KVM_F_GCLOG | KVM_F_QUIET;
-  res = ku_exec(vm, "fun M(x) { var m = x; var mm=x*2; fun e(n) { return m*n*mm; } return e; }\n var z = M(5); var x = z(3); x = nil;");
+  res = ku_exec(vm, "fun M(x) { let m = x; let mm=x*2; fun e(n) { return m*n*mm; } return e; }\n let z = M(5); let x = z(3); x = nil;");
   EXPECT_INT(vm, res, KVM_OK, "gc closure2 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "gc closure2 val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = \"hello \" + \"world\";");
+  res = ku_exec(vm, "let x = \"hello \" + \"world\";");
   int sc = kut_table_count(vm, &vm->strings);
-  res = ku_exec(vm, "var y = \"hello\" + \" world\";");
+  res = ku_exec(vm, "let y = \"hello\" + \" world\";");
   // +1 for the y value, +2 for two different substrings
   EXPECT_INT(vm, kut_table_count(vm, &vm->strings), sc+3, "string intern");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_TRACEMEM | KVM_F_TRACE | KVM_F_STACK | KVM_F_QUIET;
-  res = ku_exec(vm, "var x=1; var y=x*2;");
+  res = ku_exec(vm, "let x=1; let y=x*2;");
   EXPECT_INT(vm, res, KVM_OK, "tracing and printing");
   kut_free(vm);
   
@@ -936,67 +936,67 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "class Foo {}\nvar f = Foo(); printf(f);");
+  res = ku_exec(vm, "class Foo {}\nlet f = Foo(); printf(f);");
   EXPECT_INT(vm, res, KVM_OK, "class cons");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var c = 7; c.p = 9;");
+  res = ku_exec(vm, "let c = 7; c.p = 9;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "non-instance setprop");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var c = 7; var x = c.p;");
+  res = ku_exec(vm, "let c = 7; let x = c.p;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "non-instance getprop");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class C{}\nvar c=C(); c.p=9; var x=c.p;");
+  res = ku_exec(vm, "class C{}\nlet c=C(); c.p=9; let x=c.p;");
   EXPECT_INT(vm, res, KVM_OK, "set/get prop res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "set/get prop ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class C{}\nvar c=C(); c.p=9; var x=c.z;");
+  res = ku_exec(vm, "class C{}\nlet c=C(); c.p=9; let x=c.z;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "set/get prop not found");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_STACK | KVM_F_TRACE;
-  res = ku_exec(vm, "var x=1;\nclass C{ M() { x=3; } }\nvar c=C();\nvar m=c.M;\nm();");
+  res = ku_exec(vm, "let x=1;\nclass C{ M() { x=3; } }\nlet c=C();\nlet m=c.M;\nm();");
   EXPECT_INT(vm, res, KVM_OK, "bound method res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "bound method ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=1; class C{ M() { this.z=3; } }\nvar c=C(); c.M(); x=c.z;");
+  res = ku_exec(vm, "let x=1; class C{ M() { this.z=3; } }\nlet c=C(); c.M(); x=c.z;");
   EXPECT_INT(vm, res, KVM_OK, "this res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "this ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = this;");
+  res = ku_exec(vm, "let x = this;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "global this res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class C {}\nvar c=C(12,14);");
+  res = ku_exec(vm, "class C {}\nlet c=C(12,14);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "no init with args");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class C { init(x) { this.x = x; }}\nvar c=C(12);var x = c.x;");
+  res = ku_exec(vm, "class C { init(x) { this.x = x; }}\nlet c=C(12);let x = c.x;");
   EXPECT_INT(vm, res, KVM_OK, "init args res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(12), "init args ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class C { init(x) { this.x = x; return 7; }}\nvar c=C(12);var x = c.x;");
+  res = ku_exec(vm, "class C { init(x) { this.x = x; return 7; }}\nlet c=C(12);let x = c.x;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "init return res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=1; class C { init() { fun f() { x=8; } this.f = f; } }\nvar c = C(); c.f();");
+  res = ku_exec(vm, "let x=1; class C { init() { fun f() { x=8; } this.f = f; } }\nlet c = C(); c.f();");
   EXPECT_INT(vm, res, KVM_OK, "field invoke res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(8), "field invoke ret");
   kut_free(vm);
@@ -1012,42 +1012,42 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var B = 9; class A < B {}");
+  res = ku_exec(vm, "let B = 9; class A < B {}");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "class bad inherit run res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x = super.foo();");
+  res = ku_exec(vm, "let x = super.foo();");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "global super res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A { f() { var x = super.foo(); } }");
+  res = ku_exec(vm, "class A { f() { let x = super.foo(); } }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "no superclass super res");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=0; class A { f() { x=2; } }\nclass B < A {}\nvar b=B(); b.f();");
+  res = ku_exec(vm, "let x=0; class A { f() { x=2; } }\nclass B < A {}\nlet b=B(); b.f();");
   EXPECT_INT(vm, res, KVM_OK, "super res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2), "super ret");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = 0;
-  res = ku_exec(vm, "class A { f() { return 2; } }\nclass B < A { f() { var z=super.f; return z()*3; }}\nvar b=B(); var x = b.f();");
+  res = ku_exec(vm, "class A { f() { return 2; } }\nclass B < A { f() { let z=super.f; return z()*3; }}\nlet b=B(); let x = b.f();");
   EXPECT_INT(vm, res, KVM_OK, "super call res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "super call ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A { f() { return 2; } }\nclass B < A { f() { return super.f()*3; }}\nvar b=B(); var x = b.f();");
+  res = ku_exec(vm, "class A { f() { return 2; } }\nclass B < A { f() { return super.f()*3; }}\nlet b=B(); let x = b.f();");
   EXPECT_INT(vm, res, KVM_OK, "super invoke res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "super invoke ret");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->max_const = 1;
-  res = ku_exec(vm, "var x=1; var y=2;");
+  res = ku_exec(vm, "let x=1; let y=2;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "too many const");
   kut_free(vm);
 
@@ -1063,19 +1063,19 @@ void ku_test() {
 
   vm = kut_new(false);
   vm->max_closures = 1;
-  res = ku_exec(vm, "fun O() { var a=1; var b=2; fun I() { return a*b; } return e; }\n var z=M(); var x=z();");
+  res = ku_exec(vm, "fun O() { let a=1; let b=2; fun I() { return a*b; } return e; }\n let z=M(); let x=z();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "too many closures res");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->max_jump = 1;
-  res = ku_exec(vm, "var x = 0; for(var j=0; j < 10; j=j+1) x = j;");
+  res = ku_exec(vm, "let x = 0; for(let j=0; j < 10; j=j+1) x = j;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "max jump");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->max_body = 1;
-  res = ku_exec(vm, "var x = 0; for(var j=0; j < 10; j=j+1) x = j;");
+  res = ku_exec(vm, "let x = 0; for(let j=0; j < 10; j=j+1) x = j;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "max body");
   kut_free(vm);
 
@@ -1086,172 +1086,172 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A{}\nvar a=A(); a.x();");
+  res = ku_exec(vm, "class A{}\nlet a=A(); a.x();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "invoke invalid prop");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A{}\nvar a=7; a.x();");
+  res = ku_exec(vm, "class A{}\nlet a=7; a.x();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "invoke invalid receiver");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A{} class B<A{ f() { super.x(); }} var b=B(); b.f();");
+  res = ku_exec(vm, "class A{} class B<A{ f() { super.x(); }} let b=B(); b.f();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "invoke invalid super");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=true; var y=-x;");
+  res = ku_exec(vm, "let x=true; let y=-x;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "negate non-number");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun O() { var a=1; var b=2; fun e() { a=9; return a*b; } return e; }\n var z=O(); var x=z();");
+  res = ku_exec(vm, "fun O() { let a=1; let b=2; fun e() { a=9; return a*b; } return e; }\n let z=O(); let x=z();");
   EXPECT_INT(vm, res, KVM_OK, "closure set res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(18), "closure set ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "class A{} class B<A{ f() { var m = super.x; }} var b=B(); b.f();");
+  res = ku_exec(vm, "class A{} class B<A{ f() { let m = super.x; }} let b=B(); b.f();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "invalid get super");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_NOEXEC;
-  res = ku_exec(vm, "var x=9;");
+  res = ku_exec(vm, "let x=9;");
   EXPECT_INT(vm, res, KVM_OK, "noexec");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->max_locals = 1;
-  res = ku_exec(vm, "fun f() { var x=9; var m=2; }");
+  res = ku_exec(vm, "fun f() { let x=9; let m=2; }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "max_locals");
   kut_free(vm);
 
   vm = kut_new(false);
   vm->flags = KVM_F_GCSTRESS | KVM_F_GCLOG | KVM_F_QUIET;
-  res = ku_exec(vm, "class A{ f(){}} var a=A(); var z=a.f; a=nil;");
+  res = ku_exec(vm, "class A{ f(){}} let a=A(); let z=a.f; a=nil;");
   ku_gc(vm);
   EXPECT_INT(vm, res, KVM_OK, "gc class res");
   EXPECT_VAL(vm, ku_get_global(vm, "a"), NIL_VAL, "gc class val");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var f=fun(a) {return a*2;}; var x=f(3);");
+  res = ku_exec(vm, "let f=fun(a) {return a*2;}; let x=f(3);");
   EXPECT_INT(vm, res, KVM_OK, "anonymous function res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "anonymous func ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun f(x) { return x(7);} var x=f(fun(a) { return a*2; });");
+  res = ku_exec(vm, "fun f(x) { return x(7);} let x=f(fun(a) { return a*2; });");
   EXPECT_INT(vm, res, KVM_OK, "fun arg res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(14), "fun arg ret");
   kut_free(vm);
 
-  ku_lexinit(vm, "var x = 12+3;\nvar m=2;\nvar mm=99;");
+  ku_lexinit(vm, "let x = 12+3;\nlet m=2;\nlet mm=99;");
   ku_lexdump(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var f = a => a*2; var x=f(3);");
+  res = ku_exec(vm, "let f = a => a*2; let x=f(3);");
   EXPECT_INT(vm, res, KVM_OK, "lambda res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "lambda ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "fun f(x) { return x(2); } var x = f(a => a*3);");
+  res = ku_exec(vm, "fun f(x) { return x(2); } let x = f(a => a*3);");
   EXPECT_INT(vm, res, KVM_OK, "lambda arg res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(6), "lambda arg ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var f = { a,b => a*b }; var x=f(3,4);");
+  res = ku_exec(vm, "let f = { a,b => a*b }; let x=f(3,4);");
   EXPECT_INT(vm, res, KVM_OK, "lambda args res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(12), "lambda args ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var max = { a,b => { if (a>b) return a; else return b; }}; var x=max(3,14);");
+  res = ku_exec(vm, "let max = { a,b => { if (a>b) return a; else return b; }}; let x=max(3,14);");
   EXPECT_INT(vm, res, KVM_OK, "lambda args body res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(14), "lambda args body ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var abs = { a=> { if (a<0) return -a; else return a; }}; var x=abs(-12);");
+  res = ku_exec(vm, "let abs = { a=> { if (a<0) return -a; else return a; }}; let x=abs(-12);");
   EXPECT_INT(vm, res, KVM_OK, "lambda body res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(12), "lambda body ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x =3; break;");
+  res = ku_exec(vm, "let x =3; break;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "global break");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x =3; continue;");
+  res = ku_exec(vm, "let x =3; continue;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "global continue");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=0; while(x < 5) { if (x > 2) break; x=x+1; }");
+  res = ku_exec(vm, "let x=0; while(x < 5) { if (x > 2) break; x=x+1; }");
   EXPECT_INT(vm, res, KVM_OK, "while break res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "while break ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=0; for(var i=0; i<10; i=i+1) { if (i > 2) break;  x = i;}");
+  res = ku_exec(vm, "let x=0; for(let i=0; i<10; i=i+1) { if (i > 2) break;  x = i;}");
   EXPECT_INT(vm, res, KVM_OK, "for break res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2), "for break ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var x=0; var y=0; while(x < 5) { x=x+1; if (x > 2) continue; y=x; }");
+  res = ku_exec(vm, "let x=0; let y=0; while(x < 5) { x=x+1; if (x > 2) continue; y=x; }");
   EXPECT_INT(vm, res, KVM_OK, "while continue res");
   EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(2), "while continue ret");
   kut_free(vm);
 
   vm = kut_new(false);
-  res = ku_exec(vm, "var y=0; for(var x=0; x<5; x=x+1) { if (x > 2) continue; y=x; }");
+  res = ku_exec(vm, "let y=0; for(let x=0; x<5; x=x+1) { if (x > 2) continue; y=x; }");
   EXPECT_INT(vm, res, KVM_OK, "for continue res");
   EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(2), "for continue ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var y=\"12\"; var x=y.count;");
+  res = ku_exec(vm, "let y=\"12\"; let x=y.count;");
   EXPECT_INT(vm, res, KVM_OK, "string.count res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2), "string.count ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=v.count;");
+  res = ku_exec(vm, "let x=v.count;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.count nil");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=12; var y=x.count;");
+  res = ku_exec(vm, "let x=12; let y=x.count;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.count non num");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var y=\"12\\n\\r\\t\"; var x=y.count;");
+  res = ku_exec(vm, "let y=\"12\\n\\r\\t\"; let x=y.count;");
   EXPECT_INT(vm, res, KVM_OK, "strlit escape res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(5), "strlit escape ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=1.2e3;");
+  res = ku_exec(vm, "let x=1.2e3;");
   EXPECT_INT(vm, res, KVM_OK, "1.2e3 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1.2e3), "1.2e3 ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=0xcafeb10b;");
+  res = ku_exec(vm, "let x=0xcafeb10b;");
   EXPECT_INT(vm, res, KVM_OK, "hex res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(0xcafeb10b), "hex ret");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, 0);
-  res = ku_exec(vm, "var x=test;");
+  res = ku_exec(vm, "let x=test;");
   EXPECT_INT(vm, res, KVM_OK, "class res");
   EXPECT_TRUE(vm, IS_CCLASS(ku_get_global(vm, "x")), "class ret");
   kut_free(vm);
@@ -1259,7 +1259,7 @@ void ku_test() {
 
   vm = kut_new(false);
   tclass_init(vm, SFREE);
-  res = ku_exec(vm, "var x=test;");
+  res = ku_exec(vm, "let x=test;");
   EXPECT_INT(vm, res, KVM_OK, "class res");
   EXPECT_TRUE(vm, IS_CCLASS(ku_get_global(vm, "x")), "class ret");
   kut_free(vm);
@@ -1267,13 +1267,13 @@ void ku_test() {
 
   vm = kut_new(false);
   tclass_init(vm, 0);
-  res = ku_exec(vm, "var x=test.prop;");
+  res = ku_exec(vm, "let x=test.prop;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "class no sget res");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, SGET);
-  res = ku_exec(vm, "var x=test.prop;");
+  res = ku_exec(vm, "let x=test.prop;");
   EXPECT_INT(vm, res, KVM_OK, "class sget res");
   EXPECT_INT(vm, tclass_sget, 1, "class sget ret");
   kut_free(vm);
@@ -1299,26 +1299,26 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=math.sin(math.pi);");
+  res = ku_exec(vm, "let x=math.sin(math.pi);");
   EXPECT_INT(vm, res, KVM_OK, "math.sin res");
   EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 0), "math.sin ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=math.cos(math.pi);");
+  res = ku_exec(vm, "let x=math.cos(math.pi);");
   EXPECT_INT(vm, res, KVM_OK, "math.cos res");
   EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), -1), "math.cos ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=math.tan(math.pi/4);");
+  res = ku_exec(vm, "let x=math.tan(math.pi/4);");
   EXPECT_INT(vm, res, KVM_OK, "math.tan res");
   EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 1), "math.tan ret");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, SMARK);
-  res = ku_exec(vm, "var x=test;");
+  res = ku_exec(vm, "let x=test;");
   ku_gc(vm);
   EXPECT_INT(vm, tclass_smark, 1, "class smark false");
   res = ku_exec(vm, "x=nil;");
@@ -1328,13 +1328,13 @@ void ku_test() {
 
   vm = kut_new(false);
   tclass_init(vm, 0);
-  res = ku_exec(vm, "var x = test(4);");
+  res = ku_exec(vm, "let x = test(4);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "class no cons");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE);
-  res = ku_exec(vm, "var x = test(4);");
+  res = ku_exec(vm, "let x = test(4);");
   EXPECT_INT(vm, res, KVM_OK, "class cons res");
   EXPECT_TRUE(vm, IS_CINST(ku_get_global(vm, "x")), "class cons ret");
   kut_free(vm);
@@ -1343,7 +1343,7 @@ void ku_test() {
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE | IMARK);
   vm->flags |= KVM_F_GCSTRESS;
-  res = ku_exec(vm, "var x=test(4);");
+  res = ku_exec(vm, "let x=test(4);");
   ku_gc(vm);
   EXPECT_TRUE(vm, tclass_sfree == 0, "class sfree");
   EXPECT_INT(vm, res, KVM_OK, "class imark res");
@@ -1352,26 +1352,26 @@ void ku_test() {
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE | IGET);
-  res = ku_exec(vm, "var x=test(4); var y=x.prop;");
+  res = ku_exec(vm, "let x=test(4); let y=x.prop;");
   EXPECT_INT(vm, res, KVM_OK, "iget res");
   EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(4), "iget");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE );
-  res = ku_exec(vm, "var x=test(4); x.prop=9;");
+  res = ku_exec(vm, "let x=test(4); x.prop=9;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "no iput res");
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE | IPUT | IGET);
-  res = ku_exec(vm, "var x=test(4); x.prop=9; var y=x.prop;");
+  res = ku_exec(vm, "let x=test(4); x.prop=9; let y=x.prop;");
   EXPECT_INT(vm, res, KVM_OK, "iput res");
   EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(9), "iput");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"ABC %g,%s,%b,%b\",123.45,\"FF\", true, false);");
+  res = ku_exec(vm, "let x=string.format(\"ABC %g,%s,%b,%b\",123.45,\"FF\", true, false);");
   EXPECT_INT(vm, res, KVM_OK, "string.format res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_STR(v), "string.format ret");
@@ -1380,83 +1380,83 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%f\", 123.456);");
+  res = ku_exec(vm, "let x=string.format(\"%f\", 123.456);");
   EXPECT_INT(vm, res, KVM_OK, "string.format(%f) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "123.456000", "string.format(%f) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%f\", true);");
+  res = ku_exec(vm, "let x=string.format(\"%f\", true);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format(%f) invalid res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%x\",0xfb1cfd);");
+  res = ku_exec(vm, "let x=string.format(\"%x\",0xfb1cfd);");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "fb1cfd", "string.format %x");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%d\",123.45);");
+  res = ku_exec(vm, "let x=string.format(\"%d\",123.45);");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "123", "string.format %d");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%d\",true);");
+  res = ku_exec(vm, "let x=string.format(\"%d\",true);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format bool to %d");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%s\",true);");
+  res = ku_exec(vm, "let x=string.format(\"%s\",true);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format bool to %s");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%g\",true);");
+  res = ku_exec(vm, "let x=string.format(\"%g\",true);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format bool to %g");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%x\",true);");
+  res = ku_exec(vm, "let x=string.format(\"%x\",true);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format bool to %x");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"%b\",12);");
+  res = ku_exec(vm, "let x=string.format(\"%b\",12);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format num to %b");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(\"hello%\",12);");
+  res = ku_exec(vm, "let x=string.format(\"hello%\",12);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "string.format trailing %");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.format(12);");
+  res = ku_exec(vm, "let x=string.format(12);");
   EXPECT_INT(vm, res, KVM_OK, "string.format num res");
   EXPECT_TRUE(vm, IS_NIL(ku_get_global(vm, "x")), "string.format ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=string.bogus(12);");
+  res = ku_exec(vm, "let x=string.bogus(12);");
   EXPECT_INT(vm, res, KVM_OK, "string.bogus num res");
   EXPECT_TRUE(vm, IS_NIL(ku_get_global(vm, "x")), "string.bogus ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"123\"; var x=s.bogus;");
+  res = ku_exec(vm, "let s=\"123\"; let x=s.bogus;");
   EXPECT_INT(vm, res, KVM_OK, "s.bogus res");
   EXPECT_TRUE(vm, IS_NIL(ku_get_global(vm, "x")), "s.bogus ret");
   kut_free(vm);
 
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=math.bogus(12);");
+  res = ku_exec(vm, "let x=math.bogus(12);");
   EXPECT_INT(vm, res, KVM_OK, "math.bogus scall res");
   EXPECT_TRUE(vm, IS_NIL(ku_get_global(vm, "x")), "math.bogus scall ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=math.bogus;");
+  res = ku_exec(vm, "let x=math.bogus;");
   EXPECT_INT(vm, res, KVM_OK, "math.bogus sget res");
   EXPECT_TRUE(vm, IS_NIL(ku_get_global(vm, "x")), "math.bogus sget ret");
   kut_free(vm);
@@ -1473,21 +1473,21 @@ void ku_test() {
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE );
-  res = ku_exec(vm, "var x=test(4);");
+  res = ku_exec(vm, "let x=test(4);");
   v = ku_get_global(vm, "x");
   ku_printval(vm, v);
   kut_free(vm);
 
   vm = kut_new(false);
   tclass_init(vm, CONS | IFREE );
-  res = ku_exec(vm, "var z=\"he\"; var x=z+\"llo\";");
+  res = ku_exec(vm, "let z=\"he\"; let x=z+\"llo\";");
   v = ku_get_global(vm, "x");
   str = AS_STR(v);
-  EXPECT_INT(vm, strcmp(str->chars, "hello"), 0, "var + string ret");
+  EXPECT_INT(vm, strcmp(str->chars, "hello"), 0, "let + string ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=0xCaFeb10B;");
+  res = ku_exec(vm, "let x=0xCaFeb10B;");
   EXPECT_INT(vm, res, KVM_OK, "hex mixed case res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(0xcafeb10b), "hex mixed case ret");
   kut_free(vm);
@@ -1516,18 +1516,18 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[1,2,3;");
+  res = ku_exec(vm, "let x=[1,2,3;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "array missing ']'");
   kut_free(vm);
 
   vm = kut_new(true);
   vm->flags |= KVM_F_LIST | KVM_F_NOEXEC;
-  res = ku_exec(vm, "var x=[1,2,3,4,5];");
+  res = ku_exec(vm, "let x=[1,2,3,4,5];");
   EXPECT_INT(vm, res, KVM_OK, "OP_ARRAY disassemble");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[1,2,3];");
+  res = ku_exec(vm, "let x=[1,2,3];");
   EXPECT_INT(vm, res, KVM_OK, "array init");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array type");
@@ -1537,7 +1537,7 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[1,\"hello\",3,4];");
+  res = ku_exec(vm, "let x=[1,\"hello\",3,4];");
   EXPECT_INT(vm, res, KVM_OK, "mix array res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_ARRAY(v), "mix array type");
@@ -1550,24 +1550,24 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a[1];");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a[1];");
   EXPECT_INT(vm, res, KVM_OK, "array get res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "array get value");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a[1;");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a[1;");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "array get ']'");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; a[1]=9; var x=a[1];");
+  res = ku_exec(vm, "let a=[1,3,4]; a[1]=9; let x=a[1];");
   EXPECT_INT(vm, res, KVM_OK, "array set res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "array get value");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=array(7);");
+  res = ku_exec(vm, "let a=array(7);");
   EXPECT_INT(vm, res, KVM_OK, "array cons res");
   v = ku_get_global(vm, "a");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array cons type");
@@ -1576,7 +1576,7 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=array(0);");
+  res = ku_exec(vm, "let a=array(0);");
   EXPECT_INT(vm, res, KVM_OK, "array cons(0) res");
   v = ku_get_global(vm, "a");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array cons(0) type");
@@ -1585,13 +1585,13 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.count;");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.count;");
   EXPECT_INT(vm, res, KVM_OK, "array count res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "array count ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.map(e => e*2);");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.map(e => e*2);");
   EXPECT_INT(vm, res, KVM_OK, "array.map res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array.map type");
@@ -1601,112 +1601,112 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.map();");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.map();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.map nil");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.map(9);");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.map(9);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.map num");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.map({ e, b => e*2 });");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.map({ e, b => e*2 });");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.map args");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var sum=[1,3,4].reduce(0, {v,e => v+e});");
+  res = ku_exec(vm, "let sum=[1,3,4].reduce(0, {v,e => v+e});");
   EXPECT_INT(vm, res, KVM_OK, "array.reduce res");
   EXPECT_VAL(vm, ku_get_global(vm, "sum"), NUM_VAL(8), "array.reduce value");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var sum=[1,3,4].reduce(0, {v,e => bad()});");
+  res = ku_exec(vm, "let sum=[1,3,4].reduce(0, {v,e => bad()});");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.reduce bad fn");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var sum=[1,3,4].reduce(9);");
+  res = ku_exec(vm, "let sum=[1,3,4].reduce(9);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.reduce num");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var sum=[1,3,4].reduce();");
+  res = ku_exec(vm, "let sum=[1,3,4].reduce();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.reduce nil");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var sum=[1,3,4].reduce(0, {v=> v*2});");
+  res = ku_exec(vm, "let sum=[1,3,4].reduce(0, {v=> v*2});");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.reduce 1 arg");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x =a.bogus();");
+  res = ku_exec(vm, "let a=[1,3,4]; let x =a.bogus();");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "array.invoke bogus");
   kut_free(vm);
 
   
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.map(e => f(e));");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.map(e => f(e));");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.map arg err res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=1.23e-2;");
+  res = ku_exec(vm, "let x=1.23e-2;");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1.23e-2), "1.23e-2");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "for(var i=0; i<10; i=i+1) { if (i>2) break; if (i>3) break; }");
+  res = ku_exec(vm, "for(let i=0; i<10; i=i+1) { if (i>2) break; if (i>3) break; }");
   EXPECT_INT(vm, res, KVM_OK, "two break");
   kut_free(vm);
 
   vm = kut_new(true);
   vm->max_patches = 1;
-  res = ku_exec(vm, "for(var i=0; i<10; i=i+1) { if (i>2) break; if (i>3) break; }");
+  res = ku_exec(vm, "for(let i=0; i<10; i=i+1) { if (i>2) break; if (i>3) break; }");
   EXPECT_INT(vm, res, KVM_ERR_SYNTAX, "patch limit");
   kut_free(vm);
 
   vm = kut_new(true);
   vm->flags |= KVM_F_GCSTRESS;
-  res = ku_exec(vm, "var t=table(); t.x=1; t.y=2; var x=t.x+t.y;");
+  res = ku_exec(vm, "let t=table(); t.x=1; t.y=2; let x=t.x+t.y;");
   EXPECT_INT(vm, res, KVM_OK, "table res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "table ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.x=1; t.y=2; var x=t.z;");
+  res = ku_exec(vm, "let t=table(); t.x=1; t.y=2; let x=t.z;");
   EXPECT_INT(vm, res, KVM_OK, "table res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "table nil ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.set(\"x\",1); var x=t.get(\"x\");");
+  res = ku_exec(vm, "let t=table(); t.set(\"x\",1); let x=t.get(\"x\");");
   EXPECT_INT(vm, res, KVM_OK, "table set get res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1), "table set get ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.set(1,1); var x=t.get(\"x\");");
+  res = ku_exec(vm, "let t=table(); t.set(1,1); let x=t.get(\"x\");");
   EXPECT_INT(vm, res, KVM_OK, "table set(nil) res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "table set(nil)");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.set(\"x\",1); var x=t.get(1);");
+  res = ku_exec(vm, "let t=table(); t.set(\"x\",1); let x=t.get(1);");
   EXPECT_INT(vm, res, KVM_OK, "table get(nil) res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "table get(nil)");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); var x = t.bogus();");
+  res = ku_exec(vm, "let t=table(); let x = t.bogus();");
   EXPECT_INT(vm, res, KVM_OK, "table bogus res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "table bogus");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.x=1; t.y=2; t.z=3; var K=\"\"; var V=0; t.iter({ k,v => { K=K+k; V=V+v; }} );");
+  res = ku_exec(vm, "let t=table(); t.x=1; t.y=2; t.z=3; let K=\"\"; let V=0; t.iter({ k,v => { K=K+k; V=V+v; }} );");
   EXPECT_INT(vm, res, KVM_OK, "table iter res");
   v = ku_get_global(vm, "K");
   EXPECT_TRUE(vm, IS_STR(v), "table iter K type");
@@ -1716,79 +1716,79 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.iter(k => k);");
+  res = ku_exec(vm, "let t=table(); t.iter(k => k);");
   EXPECT_INT(vm, res, KVM_OK, "table iter argc res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.iter();");
+  res = ku_exec(vm, "let t=table(); t.iter();");
   EXPECT_INT(vm, res, KVM_OK, "table iter nil res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var t=table(); t.iter(12);");
+  res = ku_exec(vm, "let t=table(); t.iter(12);");
   EXPECT_INT(vm, res, KVM_OK, "table iter num res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.imod(9,5);");
+  res = ku_exec(vm, "let x = math.imod(9,5);");
   EXPECT_INT(vm, res, KVM_OK, "imod res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(4), "imod ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.sqrt(4);");
+  res = ku_exec(vm, "let x = math.sqrt(4);");
   EXPECT_INT(vm, res, KVM_OK, "sqrt res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2), "sqrt ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.pow(3,2);");
+  res = ku_exec(vm, "let x = math.pow(3,2);");
   EXPECT_INT(vm, res, KVM_OK, "pow res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "pow ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = int(3.2);");
+  res = ku_exec(vm, "let x = int(3.2);");
   EXPECT_INT(vm, res, KVM_OK, "int res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "int ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = int(true);");
+  res = ku_exec(vm, "let x = int(true);");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "int(bool) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = parseFloat(\"3.2\");");
+  res = ku_exec(vm, "let x = parseFloat(\"3.2\");");
   EXPECT_INT(vm, res, KVM_OK, "parseFloat res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3.2), "parseFloat ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = parseFloat(true);");
+  res = ku_exec(vm, "let x = parseFloat(true);");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "parseFloat(bool) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 0xf7f1 | 0x9854;");
+  res = ku_exec(vm, "let x = 0xf7f1 | 0x9854;");
   EXPECT_INT(vm, res, KVM_OK, "bit or res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(65525), "bit or ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 0xf7f1 & 0x9854;");
+  res = ku_exec(vm, "let x = 0xf7f1 & 0x9854;");
   EXPECT_INT(vm, res, KVM_OK, "bit and res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(36944), "bit and ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 0xf7f1 | true;");
+  res = ku_exec(vm, "let x = 0xf7f1 | true;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "bit or invalid res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 0xf7f1 & true;");
+  res = ku_exec(vm, "let x = 0xf7f1 & true;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "bit and invalid res");
   kut_free(vm);
 
@@ -1798,116 +1798,116 @@ void ku_test() {
   kut_free(vm);
   
   vm = kut_new(true);
-  ku_exec(vm, "var t=0;");
-  ku_exec(vm, "var samples=array(6);");
+  ku_exec(vm, "let t=0;");
+  ku_exec(vm, "let samples=array(6);");
   ku_exec(vm, "samples[0] = (1 + math.sin(t*1.2345 + math.cos(t*0.33457)*0.44))*0.5;");
-  res = ku_exec(vm, "var x = samples[0];");
+  res = ku_exec(vm, "let x = samples[0];");
   EXPECT_INT(vm, res, KVM_OK, "array index crash res");
   kut_free(vm);
 
   vm = kut_new(true);
-  ku_exec(vm, "var x=7, y=9;");
-  EXPECT_INT(vm, res, KVM_OK, "multi-var res");
-  EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(7), "multi-var x");
-  EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(9), "multi-var y");
+  ku_exec(vm, "let x=7, y=9;");
+  EXPECT_INT(vm, res, KVM_OK, "multi-let res");
+  EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(7), "multi-let x");
+  EXPECT_VAL(vm, ku_get_global(vm, "y"), NUM_VAL(9), "multi-let y");
   kut_free(vm);
 
   vm = kut_new(true);
-  ku_exec(vm, "var x,y;");
-  EXPECT_INT(vm, res, KVM_OK, "multi-var nil res");
-  EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "multi-var nil x");
-  EXPECT_VAL(vm, ku_get_global(vm, "y"), NIL_VAL, "multi-var nil y");
+  ku_exec(vm, "let x,y;");
+  EXPECT_INT(vm, res, KVM_OK, "multi-let nil res");
+  EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "multi-let nil x");
+  EXPECT_VAL(vm, ku_get_global(vm, "y"), NIL_VAL, "multi-let nil y");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 2 << 4;");
+  res = ku_exec(vm, "let x = 2 << 4;");
   EXPECT_INT(vm, res, KVM_OK, "shl res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2 << 4), "shl ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 2 << true;");
+  res = ku_exec(vm, "let x = 2 << true;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "shl arg res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = 16 >> 2;");
+  res = ku_exec(vm, "let x = 16 >> 2;");
   EXPECT_INT(vm, res, KVM_OK, "shr res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(16 >> 2), "shr ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = true >> 2;");
+  res = ku_exec(vm, "let x = true >> 2;");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "shr arg res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = string.frombytes([65,66,67]);");
+  res = ku_exec(vm, "let x = string.frombytes([65,66,67]);");
   EXPECT_INT(vm, res, KVM_OK, "string.frombytes res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "ABC", "string.frombytes ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,2,3]; a[0]=4; var x=a.count;");
+  res = ku_exec(vm, "let a=[1,2,3]; a[0]=4; let x=a.count;");
   EXPECT_INT(vm, res, KVM_OK, "arr change res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "arr change count");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=true; a[0]=4; ");
+  res = ku_exec(vm, "let a=true; a[0]=4; ");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "non-array set res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=true; var x = a[0]; ");
+  res = ku_exec(vm, "let a=true; let x = a[0]; ");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "non-array get res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "fun F() { var a=array(2); a[0]=1; a[1]=2; a[2]=3; return a[2]; } var x=F();");
+  res = ku_exec(vm, "fun F() { let a=array(2); a[0]=1; a[1]=2; a[2]=3; return a[2]; } let x=F();");
   EXPECT_INT(vm, res, KVM_OK, "arr nogc res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "arr no gc ret");
   kut_free(vm);
 
   vm = kut_new(true);
   vm->flags = KVM_F_GCSTRESS;
-  res = ku_exec(vm, "fun F() { var a=array(2); a[0]=1; a[1]=2; a[2]=3; return a[2]; } var x=F();");
+  res = ku_exec(vm, "fun F() { let a=array(2); a[0]=1; a[1]=2; a[2]=3; return a[2]; } let x=F();");
   EXPECT_INT(vm, res, KVM_OK, "arr gc res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "arr gc ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a = []; var x = a.first;");
+  res = ku_exec(vm, "let a = []; let x = a.first;");
   EXPECT_INT(vm, res, KVM_OK, "arr empty first res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "arr empty first ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a = [12,3]; var x = a.first;");
+  res = ku_exec(vm, "let a = [12,3]; let x = a.first;");
   EXPECT_INT(vm, res, KVM_OK, "arr first res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(12), "arr first ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a = []; var x = a.last;");
+  res = ku_exec(vm, "let a = []; let x = a.last;");
   EXPECT_INT(vm, res, KVM_OK, "arr empty last res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "arr empty last ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a = [12,3]; var x = a.last;");
+  res = ku_exec(vm, "let a = [12,3]; let x = a.last;");
   EXPECT_INT(vm, res, KVM_OK, "arr last res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(3), "arr last ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=2; var a = (x > 2) and 7 or 6;");
+  res = ku_exec(vm, "let x=2; let a = (x > 2) and 7 or 6;");
   EXPECT_INT(vm, res, KVM_OK, "tertiary res");
   EXPECT_VAL(vm, ku_get_global(vm, "a"), NUM_VAL(6), "tertiary ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.filter(e => e > 1);");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.filter(e => e > 1);");
   EXPECT_INT(vm, res, KVM_OK, "array.filter res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array.filter type");
@@ -1916,49 +1916,49 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.filter();");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.filter();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.filter nil");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.filter(9);");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.filter(9);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.filter num");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var a=[1,3,4]; var x=a.filter({ e, b => e*2 });");
+  res = ku_exec(vm, "let a=[1,3,4]; let x=a.filter({ e, b => e*2 });");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.filter args");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[7,3,4]; x.sort({ a,b => a-b });");
+  res = ku_exec(vm, "let x=[7,3,4]; x.sort({ a,b => a-b });");
   EXPECT_INT(vm, res, KVM_OK, "array.sort res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_ARRAY(v), "array.sort type");
   EXPECT_VAL(vm, ku_arrget(vm, AS_ARRAY(v), 0), NUM_VAL(3), "array.sort[0]");
   EXPECT_VAL(vm, ku_arrget(vm, AS_ARRAY(v), 1), NUM_VAL(4), "array.sort[1]");
   EXPECT_VAL(vm, ku_arrget(vm, AS_ARRAY(v), 2), NUM_VAL(7), "array.sort[2]");
-  res = ku_exec(vm, "var c = x.count;");
+  res = ku_exec(vm, "let c = x.count;");
   EXPECT_VAL(vm, ku_get_global(vm, "c"), NUM_VAL(3), "array sort count");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[7,3,4]; x.sort(a => 0);");
+  res = ku_exec(vm, "let x=[7,3,4]; x.sort(a => 0);");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.sort argc res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[7,3,4]; x.sort();");
+  res = ku_exec(vm, "let x=[7,3,4]; x.sort();");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.sort nil res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=[7,3,4]; x.sort({ a,b => false });");
+  res = ku_exec(vm, "let x=[7,3,4]; x.sort({ a,b => false });");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "array.sort res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x={\"a\"=1, \"b\"=2}; var z=x.a; var w=x.b;");
+  res = ku_exec(vm, "let x={\"a\"=1, \"b\"=2}; let z=x.a; let w=x.b;");
   EXPECT_INT(vm, res, KVM_OK, "table lit res");
   v = ku_get_global(vm, "x");
   EXPECT_TRUE(vm, IS_CINST(v), "table instance");
@@ -1967,145 +1967,145 @@ void ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var comp = { a, b => ( (a < b) and -1 or ( (a > b) and 1 or 0)) };");
+  res = ku_exec(vm, "let comp = { a, b => ( (a < b) and -1 or ( (a > b) and 1 or 0)) };");
   EXPECT_INT(vm, res, KVM_OK, "tertiary comp res");
-  res = ku_exec(vm, "var x = comp(9, 7);");
+  res = ku_exec(vm, "let x = comp(9, 7);");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1), "tertiary comp ret");
   kut_free(vm);
   
   vm = kut_new(true);
-  res = ku_exec(vm, "var comp = { a, b => ( (a < b) and -1 or ( (a > b) and 1 or 0)) };");
+  res = ku_exec(vm, "let comp = { a, b => ( (a < b) and -1 or ( (a > b) and 1 or 0)) };");
   EXPECT_INT(vm, res, KVM_OK, "db comp res");
-  res = ku_exec(vm, "var db = [ { \"name\" = \"mohsen\", \"age\"=55 }, { \"name\" = \"josh\", \"age\"=40 }];");
+  res = ku_exec(vm, "let db = [ { \"name\" = \"mohsen\", \"age\"=55 }, { \"name\" = \"josh\", \"age\"=40 }];");
   EXPECT_INT(vm, res, KVM_OK, "db init res");
   res = ku_exec(vm, "db.sort({ a,b => comp(a.name, b.name)});");
   EXPECT_INT(vm, res, KVM_OK, "db sort res");
-  res = ku_exec(vm, "var c = db.count;");
+  res = ku_exec(vm, "let c = db.count;");
   EXPECT_VAL(vm, ku_get_global(vm, "c"), NUM_VAL(2), "db sort count");
-  res = ku_exec(vm, "var f = db.first.name;");
+  res = ku_exec(vm, "let f = db.first.name;");
   EXPECT_STR(vm, ku_get_global(vm, "f"), "josh", "db sort first name");
   kut_free(vm);
   
   
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=eval(\"12/3\");");
+  res = ku_exec(vm, "let x=eval(\"12/3\");");
   EXPECT_INT(vm, res, KVM_OK, "eval res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(4), "eval ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=eval();");
+  res = ku_exec(vm, "let x=eval();");
   EXPECT_INT(vm, res, KVM_OK, "eval arg res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "eval arg ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x=eval(\"12/3\", 10);");
+  res = ku_exec(vm, "let x=eval(\"12/3\", 10);");
   EXPECT_INT(vm, res, KVM_OK, "eval stack res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(4), "eval stack ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr();");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr();");
   EXPECT_INT(vm, res, KVM_OK, "substr() res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "012345678", "substr() ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(3);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(3);");
   EXPECT_INT(vm, res, KVM_OK, "substr(3) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "345678", "substr(3) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(3,5);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(3,5);");
   EXPECT_INT(vm, res, KVM_OK, "substr(3,5) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "345", "substr(3,5) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(-1);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(-1);");
   EXPECT_INT(vm, res, KVM_OK, "substr(-1) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "8", "substr(-1) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(-3,-1);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(-3,-1);");
   EXPECT_INT(vm, res, KVM_OK, "substr(-3,-1) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "678", "substr(-1) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(-12,55);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(-12,55);");
   EXPECT_INT(vm, res, KVM_OK, "substr(-12,55) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "012345678", "substr(-12,5) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.substr(-12,55, true);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.substr(-12,55, true);");
   EXPECT_INT(vm, res, KVM_OK, "substr(-12,55, true) res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "", "substr(-12,5, true) ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s.bogus(-1,55);");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s.bogus(-1,55);");
   EXPECT_INT(vm, res, KVM_OK, "string.bogus res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NIL_VAL, "string.bogus ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s[2];");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s[2];");
   EXPECT_INT(vm, res, KVM_OK, "str[idx] res");
   EXPECT_STR(vm, ku_get_global(vm, "x"), "2", "str[idx] ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s[-1];");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s[-1];");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "str[idx] bounds low res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s[22];");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s[22];");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "str[idx] bounds high res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var s=\"012345678\"; var x=s[true];");
+  res = ku_exec(vm, "let s=\"012345678\"; let x=s[true];");
   EXPECT_INT(vm, res, KVM_ERR_RUNTIME, "str[bool]  res");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.fmod(9,7);");
+  res = ku_exec(vm, "let x = math.fmod(9,7);");
   EXPECT_INT(vm, res, KVM_OK, "fmod res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(fmod(9,7)), "fmod ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.abs(-7);");
+  res = ku_exec(vm, "let x = math.abs(-7);");
   EXPECT_INT(vm, res, KVM_OK, "abs negative res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(-1), "abs negative ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.abs(7);");
+  res = ku_exec(vm, "let x = math.abs(7);");
   EXPECT_INT(vm, res, KVM_OK, "abs positive res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1), "abs positive ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.abs(0);");
+  res = ku_exec(vm, "let x = math.abs(0);");
   EXPECT_INT(vm, res, KVM_OK, "abs 0 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(0), "abs 0 ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.floor(3.767);");
+  res = ku_exec(vm, "let x = math.floor(3.767);");
   EXPECT_INT(vm, res, KVM_OK, "floor res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(floor(3.767)), "floor ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "var x = math.round(3.767);");
+  res = ku_exec(vm, "let x = math.round(3.767);");
   EXPECT_INT(vm, res, KVM_OK, "round res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(round(3.767)), "round ret");
   kut_free(vm);


### PR DESCRIPTION
In Kumu, "var" behaves like "let" in javascript. This changes "var" to "let" to bring Kumu closer to a subet of javascript.

One thing to note is that I did not change all instances of the word "var" to "let" in the repo. There are concepts like "vardecl" which I think still makes sense given that "vardecl" is the common way to reference a variable declaration, regardless of the keyword that 