### PR TITLE
Add `make cov`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@
 .DS_Store
 .vs
 xcuserdata
+/build
 /out

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 #!/usr/bin/make -f
 
-# Declare this first, so that it is the default target.
+# Declare the help target first, so that it is the default target.
+usage=help::;@echo "  $(1)		$(2)"
 .PHONY: help
 help::
+	@echo "Usage: make target..."
+	@echo ""
+	@echo "Targets:"
+$(call usage,help,Prints this usage message.)
+
+.PHONY: all
+all::
 
 # Remove the default compiler from Make, while still allowing for a custom compiler to be specified by the environment.
 ifeq ($(origin CC),default)
@@ -15,8 +23,7 @@ C_STD?=c11
 CFLAGS+=-Wall -Werror -std=$(C_STD)
 # TODO: add "-Wextra -pedantic"
 
-out:
-	@mkdir $@
+out:;@mkdir $@
 
 out/%.o: kumu/%.c | out
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
@@ -27,33 +34,25 @@ out/kumu: out/kumu.o out/kumain.o out/main.o
 out/test: out/kumu.o out/kutest.o out/testmain.o
 	$(CC) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
-.PHONY: all
-all::
-
+$(call usage,kumu,Build the REPL CLI (out/kumu).)
+all:: kumu
 .PHONY: kumu
 kumu: out/kumu
-all:: kumu
 
+$(call usage,run,Runs the REPL CLI.)
 .PHONY: run
 run: out/kumu
-	$<
+	@$<
 
+$(call usage,test,Build and run the unit tests (out/test).)
+all:: test
 .PHONY: test
 test: out/test
-	$<
-all:: test
+	@$<
 
+$(call usage,clean,Prints this usage message.)
 .PHONY: clean
 clean:
 	$(RM) -r out/*
 
-help::
-	@echo "Usage: make target..."
-	@echo ""
-	@echo "Targets:"
-	@echo "  kumu       Build the REPL CLI (out/kumu)."
-	@echo "  run        Runs the REPL CLI."
-	@echo "  test       Build and run the unit tests (out/test)."
-	@echo "  clean      Cleans all build artifacts."
-	@echo "  all        Build all of the output targets (out/*)."
-	@echo "  help       Prints this usage message."
+help::;@echo ""

--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,29 @@ endif # CC
 C_STD?=c11
 CFLAGS+=-Wall -Werror -std=$(C_STD)
 # TODO: add "-Wextra -pedantic"
+LLVMCOVFLAGS=-fprofile-instr-generate -fcoverage-mapping
+LLVMCOVLDFLAGS=-fprofile-instr-generate
+LLVM_PROFRAW_FILE=build/debug/kumu.profraw
+LLVM_PROFDATA_FILE=build/debug/kumu.profdata
+LLVM_COV?=xcrun llvm-cov
+LLVM_PROFDATA?=xcrun llvm-profdata
 
+build:;@mkdir $@
+build/debug:|build;@mkdir $@
+build/release:|build;@mkdir $@
 out:;@mkdir $@
 
-out/%.o: kumu/%.c | out
-	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
+build/debug/%.o: kumu/%.c | build/debug
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LLVMCOVFLAGS) -g -c $< -o $@
 
-out/kumu: out/kumu.o out/kumain.o out/main.o
+build/release/%.o: kumu/%.c | build/release
+	$(CC) $(CFLAGS) $(CPPFLAGS) -Oz -c $< -o $@
+
+out/kumu: build/release/kumu.o build/release/kumain.o build/release/main.o | out
 	$(CC) $(LDFLAGS) $(LDLIBS) $^ -o $@
 
-out/test: out/kumu.o out/kutest.o out/testmain.o
-	$(CC) $(LDFLAGS) $(LDLIBS) $^ -o $@
+out/test: build/debug/kumu.o build/debug/kutest.o build/debug/testmain.o | out
+	$(CC) $(LDFLAGS) $(LDLIBS) $(LLVMCOVLDFLAGS) $^ -o $@
 
 $(call usage,kumu,Build the REPL CLI (out/kumu).)
 all:: kumu
@@ -42,17 +54,27 @@ kumu: out/kumu
 $(call usage,run,Runs the REPL CLI.)
 .PHONY: run
 run: out/kumu
-	@$<
+	$<
 
 $(call usage,test,Build and run the unit tests (out/test).)
 all:: test
 .PHONY: test
 test: out/test
-	@$<
+	LLVM_PROFILE_FILE=$(LLVM_PROFRAW_FILE) $<
+
+$(call usage,cov,Get test coverage of kumu core (excludes tests and main).)
+all:: cov
+.PHONY: cov
+cov: test
+	$(LLVM_PROFDATA) merge -sparse $(LLVM_PROFRAW_FILE) -o $(LLVM_PROFDATA_FILE)
+	$(LLVM_COV) show -show-branches=count -show-expansions -show-line-counts-or-regions -format=html -output-dir=out/cov -instr-profile=$(LLVM_PROFDATA_FILE) build/debug/kumu.o
+	$(LLVM_COV) report -instr-profile=$(LLVM_PROFDATA_FILE) build/debug/kumu.o
+	@echo Coverage details: out/cov/index.html
 
 $(call usage,clean,Prints this usage message.)
 .PHONY: clean
 clean:
+	$(RM) -r build/*
 	$(RM) -r out/*
 
 help::;@echo ""


### PR DESCRIPTION
This adds code coverage reports without needing to run Xcode. As with other make commands, this currently only works on MacOS, with Xcode installed. Other platform support will be added later.

```
% make clean cov
rm -f -r build/*
rm -f -r out/*
clang -Wall -Werror -std=c11 -fprofile-instr-generate -fcoverage-mapping -g -c kumu/kumu.c -o build/debug/kumu.o
clang -Wall -Werror -std=c11 -fprofile-instr-generate -fcoverage-mapping -g -c kumu/kutest.c -o build/debug/kutest.o
clang -Wall -Werror -std=c11 -fprofile-instr-generate -fcoverage-mapping -g -c kumu/testmain.c -o build/debug/testmain.o
clang -fprofile-instr-generate build/debug/kumu.o build/debug/kutest.o build/debug/testmain.o -o out/test
LLVM_PROFILE_FILE=build/debug/kumu.profraw out/test
0.000000
1.000000
2.000000
3.000000
4.000000
5.000000
6.000000
7.000000
8.000000
9.000000
[ PASSED ] 509 test
[ WARN ] 0 test
[ FAILED ] 0 test
xcrun llvm-profdata merge -sparse build/debug/kumu.profraw -o build/debug/kumu.profdata
xcrun llvm-cov show -show-branches=count -show-expansions -show-line-counts-or-regions -format=html -output-dir=out/cov -instr-profile=build/debug/kumu.profdata build/debug/kumu.o
xcrun llvm-cov report -instr-profile=build/debug/kumu.profdata build/debug/kumu.o
Filename Regions Missed Regions Cover Functions Missed Functions Executed Lines Missed Lines Cover Branches Missed Branches Cover
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
kumu.c 2809 67 97.61% 217 0 100.00% 3270 71 97.83% 1580 147 90.70%
kumu.h 2 0 100.00% 2 0 100.00% 10 0 100.00% 0 0 -
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL 2811 67 97.62% 219 0 100.00% 3280 71 97.84% 1580 147 90.70%
Coverage details: out/cov/index.html
```
<img width="782" alt="Screen Shot 2022-09-11 at 1 13 22 PM" src="https://user-images.githubusercontent.com/51454/189540504-6cf55a7c-cbd4-4c7c-8ada-8ab2a85b09cc.png">
