### PR TITLE
Add make install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 #!/usr/bin/make -f
 
+# Standard make paths
+prefix?=/usr/local
+exec_prefix?=$(prefix)
+bindir?=$(exec_prefix)/bin
+binpath?=$(bindir)/kumu
+
 # Declare the help target first, so that it is the default target.
 usage=help::;@echo "  $(1)		$(2)"
 .PHONY: help
@@ -47,6 +53,17 @@ out/kumu: build/release/kumu.o build/release/kumain.o build/release/main.o | out
 out/test: build/debug/kumu.o build/debug/kutest.o build/debug/testmain.o | out
 	$(CC) $(LDFLAGS) $(LDLIBS) $(LLVMCOVLDFLAGS) $^ -o $@
 
+$(call usage,install,Install the kumu REPL CLI ($(binpath)).)
+all:: install
+.PHONY: install
+install: out/kumu
+	cp -f $< $(binpath)
+
+$(call usage,uninstall,Uninstall the kumu REPL CLI ($(binpath)).)
+.PHONY: uninstall
+uninstall:
+	rm -f $(binpath)
+
 $(call usage,kumu,Build the REPL CLI (out/kumu).)
 all:: kumu
 .PHONY: kumu
@@ -77,5 +94,9 @@ $(call usage,clean,Prints this usage message.)
 clean:
 	$(RM) -r build/*
 	$(RM) -r out/*
+
+.PHONY: env
+env:
+	@echo bindir: $(bindir)
 
 help::;@echo ""


### PR DESCRIPTION
This copies (or removes) the kumu REPL CLI to /usr/local/bin.  This only works right now for *nix systems, and will later need to be adapted for Windows.  The path can be overridden when calling make.

make prefix=/my/custom/prefix/path install

(or override exec_prefix, bindir, or binpath)