### PR TITLE
Update math library to look similar to the Javascript version

### DIFF
--- a/kumu/kumu.c
+++ b/kumu/kumu.c
@@ -3250,6 +3250,12 @@ kuval math_scall(KU_UNUSED kuvm *__nonnull vm, kustr *__nonnull m, int argc, kuv
   return NULL_VAL;
 }
 
+kuval math_sget(KU_UNUSED kuvm *__nonnull vm, kustr *__nonnull p) {
+  if (M2(p, "PI")) {
+    return NUM_VAL(M_PI);
+  }
+  return NULL_VAL;
+}
 
 // ********************** table **********************
 kuval table_cons(kuvm *__nonnull vm, KU_UNUSED int argc, KU_UNUSED kuval *__nullable argv) {
@@ -3429,13 +3435,6 @@ kuval string_icall(kuvm *__nonnull vm, kuobj *__nonnull o, kustr *__nonnull m, i
   return NULL_VAL;
 }
 
-kuval math_sget(KU_UNUSED kuvm *__nonnull vm, kustr *__nonnull p) {
-  if (M2(p, "pi")) {
-    return NUM_VAL(M_PI);
-  }
-  return NULL_VAL;
-}
-
 void ku_reglibs(kuvm *__nonnull vm) {
   ku_cfuncdef(vm, "clock", ku_clock);
   ku_cfuncdef(vm, "int", ku_intf);
@@ -3444,7 +3443,7 @@ void ku_reglibs(kuvm *__nonnull vm) {
   ku_cfuncdef(vm, "array", ku_arraycons);
   ku_cfuncdef(vm, "eval", ku_eval);
 
-  kucclass *__nonnull math = ku_cclassnew(vm, "math");
+  kucclass *__nonnull math = ku_cclassnew(vm, "Math");
   math->sget = math_sget;
   math->scall = math_scall;
   ku_cclassdef(vm, math);

--- a/kumu/kutest.c
+++ b/kumu/kutest.c
@@ -1353,21 +1353,21 @@ int ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x=math.sin(math.pi);");
-  EXPECT_INT(vm, res, KVM_OK, "math.sin res");
-  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 0), "math.sin ret");
+  res = ku_exec(vm, "let x = Math.sin(Math.PI);");
+  EXPECT_INT(vm, res, KVM_OK, "Math.sin res");
+  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 0), "Math.sin ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x=math.cos(math.pi);");
-  EXPECT_INT(vm, res, KVM_OK, "math.cos res");
-  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), -1), "math.cos ret");
+  res = ku_exec(vm, "let x = Math.cos(Math.PI);");
+  EXPECT_INT(vm, res, KVM_OK, "Math.cos res");
+  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), -1), "Math.cos ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x=math.tan(math.pi/4);");
-  EXPECT_INT(vm, res, KVM_OK, "math.tan res");
-  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 1), "math.tan ret");
+  res = ku_exec(vm, "let x = Math.tan(Math.PI/4);");
+  EXPECT_INT(vm, res, KVM_OK, "Math.tan res");
+  EXPECT_TRUE(vm, APPROX(ku_get_global(vm, "x"), 1), "Math.tan ret");
   kut_free(vm);
 
   vm = kut_new(false);
@@ -1504,19 +1504,19 @@ int ku_test() {
 
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x=math.bogus(12);");
-  EXPECT_INT(vm, res, KVM_OK, "math.bogus scall res");
-  EXPECT_TRUE(vm, IS_NULL(ku_get_global(vm, "x")), "math.bogus scall ret");
+  res = ku_exec(vm, "let x = Math.bogus(12);");
+  EXPECT_INT(vm, res, KVM_OK, "Math.bogus scall res");
+  EXPECT_TRUE(vm, IS_NULL(ku_get_global(vm, "x")), "Math.bogus scall ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x=math.bogus;");
-  EXPECT_INT(vm, res, KVM_OK, "math.bogus sget res");
-  EXPECT_TRUE(vm, IS_NULL(ku_get_global(vm, "x")), "math.bogus sget ret");
+  res = ku_exec(vm, "let x = Math.bogus;");
+  EXPECT_INT(vm, res, KVM_OK, "Math.bogus sget res");
+  EXPECT_TRUE(vm, IS_NULL(ku_get_global(vm, "x")), "Math.bogus sget ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  v = ku_get_global(vm, "math");
+  v = ku_get_global(vm, "Math");
   ku_printval(vm, v);
   kut_free(vm);
 
@@ -1779,19 +1779,19 @@ int ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.imod(9,5);");
+  res = ku_exec(vm, "let x = Math.imod(9,5);");
   EXPECT_INT(vm, res, KVM_OK, "imod res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(4), "imod ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.sqrt(4);");
+  res = ku_exec(vm, "let x = Math.sqrt(4);");
   EXPECT_INT(vm, res, KVM_OK, "sqrt res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(2), "sqrt ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.pow(3,2);");
+  res = ku_exec(vm, "let x = Math.pow(3,2);");
   EXPECT_INT(vm, res, KVM_OK, "pow res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(9), "pow ret");
   kut_free(vm);
@@ -1848,7 +1848,7 @@ int ku_test() {
   vm = kut_new(true);
   ku_exec(vm, "let t=0;");
   ku_exec(vm, "let samples=array(6);");
-  ku_exec(vm, "samples[0] = (1 + math.sin(t*1.2345 + math.cos(t*0.33457)*0.44))*0.5;");
+  ku_exec(vm, "samples[0] = (1 + Math.sin(t*1.2345 + Math.cos(t*0.33457)*0.44))*0.5;");
   res = ku_exec(vm, "let x = samples[0];");
   EXPECT_INT(vm, res, KVM_OK, "array index crash res");
   kut_free(vm);
@@ -2123,37 +2123,37 @@ int ku_test() {
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.fmod(9,7);");
+  res = ku_exec(vm, "let x = Math.fmod(9,7);");
   EXPECT_INT(vm, res, KVM_OK, "fmod res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(fmod(9,7)), "fmod ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.abs(-7);");
+  res = ku_exec(vm, "let x = Math.abs(-7);");
   EXPECT_INT(vm, res, KVM_OK, "abs negative res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(-1), "abs negative ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.abs(7);");
+  res = ku_exec(vm, "let x = Math.abs(7);");
   EXPECT_INT(vm, res, KVM_OK, "abs positive res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(1), "abs positive ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.abs(0);");
+  res = ku_exec(vm, "let x = Math.abs(0);");
   EXPECT_INT(vm, res, KVM_OK, "abs 0 res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(0), "abs 0 ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.floor(3.767);");
+  res = ku_exec(vm, "let x = Math.floor(3.767);");
   EXPECT_INT(vm, res, KVM_OK, "floor res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(floor(3.767)), "floor ret");
   kut_free(vm);
 
   vm = kut_new(true);
-  res = ku_exec(vm, "let x = math.round(3.767);");
+  res = ku_exec(vm, "let x = Math.round(3.767);");
   EXPECT_INT(vm, res, KVM_OK, "round res");
   EXPECT_VAL(vm, ku_get_global(vm, "x"), NUM_VAL(round(3.767)), "round ret");
   kut_free(vm);


### PR DESCRIPTION
This just takes the current math library and changes around some naming to make it look more similar to the Javascript version. There are still a number of changes to be made to make the libraries look and function the same.